### PR TITLE
Patch #establish_connection to do Multidb.init

### DIFF
--- a/lib/multidb/balancer.rb
+++ b/lib/multidb/balancer.rb
@@ -102,6 +102,7 @@ module Multidb
 
     class << self
       delegate :use, :current_connection, :disconnect!, to: :balancer
+
       def use(name, &block)
         Multidb.balancer.use(name, &block)
       end

--- a/lib/multidb/model_extensions.rb
+++ b/lib/multidb/model_extensions.rb
@@ -1,24 +1,28 @@
+require 'active_record/base'
+
 module Multidb
   module ModelExtensions
-
     extend ActiveSupport::Concern
 
     included do
       class << self
+        alias_method_chain :establish_connection, :multidb
         alias_method_chain :connection, :multidb
       end
     end
 
     module ClassMethods
+      def establish_connection_with_multidb(spec = nil)
+        establish_connection_without_multidb(spec)
+        Multidb.init(connection_pool.spec.config)
+      end
+
       def connection_with_multidb
-        if (balancer = Multidb.balancer)
-          balancer.current_connection
-        else
-          connection_without_multidb
-        end
+        Multidb.balancer.current_connection
+      rescue Multidb::NotInitializedError
+        connection_without_multidb
       end
     end
-
   end
 end
 

--- a/spec/balancer_spec.rb
+++ b/spec/balancer_spec.rb
@@ -3,8 +3,8 @@ require_relative 'spec_helper'
 describe 'Multidb.balancer' do
 
   context 'with no configuration' do
-    it 'returns nothing' do
-      Multidb.balancer.should eq nil
+    it 'raises exception' do
+      -> { Multidb.balancer }.should raise_error(Multidb::NotInitializedError)
     end
   end
 
@@ -29,18 +29,18 @@ describe 'Multidb.balancer' do
   end
 
   describe '#use' do
-    context 'with no configuration' do
-      it 'raises exception' do
-        -> {
-          Multidb.use(:something) do
-          end
-        }.should raise_error(ArgumentError)
-      end
-    end
-
     context 'with configuration' do
       before do
         ActiveRecord::Base.establish_connection(configuration_with_slaves)
+      end
+
+      context 'undefined connection' do
+        it 'raises exception' do
+          -> {
+            Multidb.use(:something) do
+            end
+          }.should raise_error(ArgumentError)
+        end
       end
 
       it 'returns default connection on :default' do


### PR DESCRIPTION
We've had issues with running rake tasks when using `multidb`. I've reworked its initialization a bit. Now it happens every time `establish_connection` is called inside which I'm passing connection config to `multidb` instead of doing that when accession `connection`.

/cc @tamird
