### PR TITLE
Add support for database aliases

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -81,6 +81,23 @@ If multiple elements are specified, Multidb will use the list to pick a random c
 
 The database hashes follow the same format as the top-level adapter configuration. In other words, each database connection may override the adapter, database name, username and so on.
 
+You may also add an "alias" record to the configuration to support more than one name for a given database configuration.
+
+    production:
+      adapter: postgresql
+      database: myapp_production
+      username: ohoh
+      password: mymy
+      host: db1
+      multidb:
+        databases:
+          main_db:
+            host: db1-a
+          secondary_db:
+            alias: main_db
+
+With the above, `Multidb.use(:main_db)` and `Multidb.use(:secondary_db)` will work identically. This can be useful to support naming scheme migrations transparently: once your application is updated to use `secondary_db` where necessary, you can swap out the configuration.
+
 To use the connection, modify your code by wrapping database access logic in blocks:
 
     Multidb.use(:slave) do

--- a/lib/multidb/balancer.rb
+++ b/lib/multidb/balancer.rb
@@ -28,6 +28,11 @@ module Multidb
       databases.each_pair do |name, config|
         configs = config.is_a?(Array) ? config : [config]
         configs.each do |config|
+          if config["alias"]
+            @candidates[name] = @candidates[config["alias"]]
+            next
+          end
+
           candidate = Candidate.new(name, @default_configuration.default_adapter.merge(config))
           @candidates[name] ||= []
           @candidates[name].push(candidate)
@@ -45,6 +50,9 @@ module Multidb
       raise ArgumentError, "No such database connection '#{name}'" if candidates.empty?
       candidate = candidates.respond_to?(:sample) ?
         candidates.sample : candidates[rand(candidates.length)]
+      spec = candidate.connection_pool.spec
+      spec.config[:shard] = name
+      candidate.connection_pool.instance_variable_set(:@spec, spec)
       block_given? ? yield(candidate) : candidate
     end
 

--- a/lib/multidb/balancer.rb
+++ b/lib/multidb/balancer.rb
@@ -50,9 +50,6 @@ module Multidb
       raise ArgumentError, "No such database connection '#{name}'" if candidates.empty?
       candidate = candidates.respond_to?(:sample) ?
         candidates.sample : candidates[rand(candidates.length)]
-      spec = candidate.connection_pool.spec
-      spec.config[:shard] = name
-      candidate.connection_pool.instance_variable_set(:@spec, spec)
       block_given? ? yield(candidate) : candidate
     end
 

--- a/spec/balancer_spec.rb
+++ b/spec/balancer_spec.rb
@@ -134,6 +134,11 @@ describe 'Multidb.balancer' do
         end
       end
 
+      it "returns the parent connection for aliases" do
+        Multidb.use(:slave1).should_not eq Multidb.use(:slave4)
+        Multidb.use(:slave2).should eq Multidb.use(:slave4)
+      end
+
       it 'returns random candidate' do
         names = []
         100.times do

--- a/spec/balancer_spec.rb
+++ b/spec/balancer_spec.rb
@@ -134,9 +134,9 @@ describe 'Multidb.balancer' do
         end
       end
 
-      it "returns the parent connection for aliases" do
-        Multidb.use(:slave1).should_not eq Multidb.use(:slave4)
-        Multidb.use(:slave2).should eq Multidb.use(:slave4)
+      it 'returns the parent connection for aliases' do
+        Multidb.use(:slave1).should_not eq Multidb.use(:slave_alias)
+        Multidb.use(:slave2).should eq Multidb.use(:slave_alias)
       end
 
       it 'returns random candidate' do

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -14,7 +14,7 @@ multidb:
     slave3:
       - database: spec/test-slave3-1.sqlite
       - database: spec/test-slave3-2.sqlite
-    slave4:
+    slave_alias:
       database: spec/test-slave2.sqlite
       alias: slave2
 end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -14,6 +14,9 @@ multidb:
     slave3:
       - database: spec/test-slave3-1.sqlite
       - database: spec/test-slave3-2.sqlite
+    slave4:
+      database: spec/test-slave2.sqlite
+      alias: slave2
 end
   end
 


### PR DESCRIPTION
Re-application of https://github.com/OutOfOrder/multidb/pull/18

We have been using this in production for a while (Ruby 1.9.3, Rails 3.2.22.5) at a very large scale and everything works fine.

We are in the process of upgrading our infrastructure + getting rid of local forks, this has been hanging there for too long.

cc @astorije