### PR TITLE
Fix definition of LogSubscriberExtension#debug to match Rails

### DIFF
--- a/lib/multidb/log_subscriber.rb
+++ b/lib/multidb/log_subscriber.rb
@@ -8,11 +8,11 @@ module Multidb
       super
     end
 
-    def debug(msg)
+    def debug(msg = nil)
       name = Multidb.balancer.current_connection_name
       if name
         db = color("[DB: #{name}]", ActiveSupport::LogSubscriber::GREEN, true)
-        super(db + msg)
+        super(db + msg.to_s)
       else
         super
       end


### PR DESCRIPTION
Fixes issue #39, where the signature of `LogSubscriberExtension#debug` didn't quite match the original in Rails, causing exceptions.