### PR TITLE
chore: update gemspec for changelog and source code location

### DIFF
--- a/ar-multidb.gemspec
+++ b/ar-multidb.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |s|
   s.summary     = s.description = 'Multidb is an ActiveRecord extension for switching between multiple database connections, such as primary/replica setups.'
   s.license     = 'MIT'
   s.metadata['rubygems_mfa_required'] = 'true'
+  s.metadata['changelog_uri'] = 'https://github.com/OutOfOrder/multidb/blob/master/CHANGELOG.md'
+  s.metadata['source_code_uri'] = 'https://github.com/OutOfOrder/multidb'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
This allows for easier to find source code and changelog information through rubygems.org. Useful if you are using dependabot or other tools that use this information to see what has changed since previous releases etc.

Thanks in advance for all the work on this project as well!