### PR TITLE
Add support and testing for new versions

### DIFF
--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -16,25 +16,22 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-        - '2.5'
-        - '2.7'
         - '3.0'
+        - '3.1'
+        - '3.2'
+        - '3.3'
+        - '3.4'
         activerecord:
-        - '5.1'
-        - '5.2'
-        - '6.0'
-        - '6.1'
-        - '7.0'
         - '7.1'
+        - '7.2'
+        - '8.0'
         exclude:
-        - ruby: '2.5'
-          activerecord: '7.0'
-        - ruby: '2.5'
-          activerecord: '7.1'
         - ruby: '3.0'
-          activerecord: '5.1'
+          activerecord: '7.2'
         - ruby: '3.0'
-          activerecord: '5.2'
+          activerecord: '8.0'
+        - ruby: '3.1'
+          activerecord: '8.0'
     env:
       BUNDLE_GEMFILE: "${{ github.workspace }}/gemfiles/activerecord-${{ matrix.activerecord }}.gemfile"
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /pkg
 *~
 \.DS_Store
-*.sqlite
+*.sqlite*
 Gemfile.lock
 Gemfile.local
 gemfiles/*.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,14 +1,14 @@
-require:
+plugins:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 3.0
   SuggestExtensions: false
   NewCops: disable
   Exclude:
     - '**/vendor/**/*'
 
-Gemspec/DateAssignment: # new in 1.10
+Gemspec/DeprecatedAttributeAssignment: # new in 1.30
   Enabled: true
 Gemspec/RequireMFA: # new in 1.23
   Enabled: true
@@ -27,9 +27,6 @@ Layout/SpaceBeforeBrackets: # new in 1.7
 
 Lint/AmbiguousAssignment: # new in 1.7
   Enabled: true
-Lint/AmbiguousBlockAssociation:
-  IgnoredMethods:
-    - change
 Lint/AmbiguousOperatorPrecedence: # new in 1.21
   Enabled: true
 Lint/AmbiguousRange: # new in 1.19
@@ -110,6 +107,8 @@ RSpec/MultipleExpectations:
   Enabled: false
 RSpec/NestedGroups:
   Max: 4
+RSpec/VerifiedDoubleReference: # new in 2.10
+  Enabled: false
 
 Security/CompoundHash: # new in 1.28
   Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+## [0.8.0]
+### Changed
+- dropped support for Ruby < 3.0
+- dropped support for AR < 7.1
+- add support for Rails 7.2 and 8.0
+
 ## [0.7.0]
 ### Changed
 - add AR 7.1 support

--- a/ar-multidb.gemspec
+++ b/ar-multidb.gemspec
@@ -16,20 +16,19 @@ Gem::Specification.new do |s|
   s.metadata['source_code_uri'] = 'https://github.com/OutOfOrder/multidb'
 
   s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 3.0.0'
 
-  s.add_runtime_dependency 'activerecord', '>= 5.1', '< 7.2'
-  s.add_runtime_dependency 'activesupport', '>= 5.1', '< 7.2'
+  s.add_runtime_dependency 'activerecord', '>= 7.1', '< 8.1'
+  s.add_runtime_dependency 'activesupport', '>= 7.1', '< 8.1'
 
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3.8'
-  s.add_development_dependency 'rubocop', '~> 1.28.0'
-  s.add_development_dependency 'rubocop-rspec', '~> 2.10.0'
-  s.add_development_dependency 'simplecov', '~> 0.21.2'
+  s.add_development_dependency 'rubocop', '~> 1.75.0'
+  s.add_development_dependency 'rubocop-rspec', '~> 3.6.0'
+  s.add_development_dependency 'simplecov', '~> 0.22.0'
   s.add_development_dependency 'simplecov-lcov', '~> 0.8.0'
-  s.add_development_dependency 'sqlite3', '~> 1.3'
+  s.add_development_dependency 'sqlite3', '~> 2'
 end

--- a/gemfiles/activerecord-5.2.gemfile
+++ b/gemfiles/activerecord-5.2.gemfile
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://rubygems.org'
-
-gem 'activerecord', '~> 5.2.0'
-
-gemspec path: '..'

--- a/gemfiles/activerecord-6.0.gemfile
+++ b/gemfiles/activerecord-6.0.gemfile
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://rubygems.org'
-
-gem 'activerecord', '~> 6.0.0'
-
-gemspec path: '..'

--- a/gemfiles/activerecord-7.0.gemfile
+++ b/gemfiles/activerecord-7.0.gemfile
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://rubygems.org'
-
-gem 'activerecord', '~> 7.0.0'
-
-gemspec path: '..'

--- a/gemfiles/activerecord-7.2.gemfile
+++ b/gemfiles/activerecord-7.2.gemfile
@@ -2,6 +2,6 @@
 
 source 'https://rubygems.org'
 
-gem 'activerecord', '~> 6.1.0'
+gem 'activerecord', '~> 7.2.0'
 
 gemspec path: '..'

--- a/gemfiles/activerecord-8.0.gemfile
+++ b/gemfiles/activerecord-8.0.gemfile
@@ -2,6 +2,6 @@
 
 source 'https://rubygems.org'
 
-gem 'activerecord', '~> 5.1.0'
+gem 'activerecord', '~> 8.0.0'
 
 gemspec path: '..'

--- a/lib/multidb/candidate.rb
+++ b/lib/multidb/candidate.rb
@@ -2,19 +2,14 @@
 
 module Multidb
   class Candidate
-    USE_RAILS_61 = Gem::Version.new(::ActiveRecord::VERSION::STRING) >= Gem::Version.new('6.1')
-    SPEC_NAME = if USE_RAILS_61
-                  'ActiveRecord::Base'
-                else
-                  'primary'
-                end
+    SPEC_NAME = 'ActiveRecord::Base'
 
     def initialize(name, target)
       @name = name
 
       case target
       when Hash
-        target = target.merge(name: 'primary') unless USE_RAILS_61
+        target = target.merge(name: 'primary')
 
         @connection_handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
         @connection_handler.establish_connection(target)

--- a/lib/multidb/version.rb
+++ b/lib/multidb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Multidb
-  VERSION = '0.7.0'
+  VERSION = '0.8.0'
 end

--- a/spec/lib/multidb/balancer_spec.rb
+++ b/spec/lib/multidb/balancer_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Multidb::Balancer do
       end
 
       it 'sets fallback to false' do
-        expect(subject.fallback).to eq(false)
+        expect(subject.fallback).to be(false)
       end
 
       context 'when rails ENV is development' do
@@ -45,7 +45,7 @@ RSpec.describe Multidb::Balancer do
         end
 
         it 'sets fallback to true' do
-          expect(subject.fallback).to eq(true)
+          expect(subject.fallback).to be(true)
         end
       end
 
@@ -55,7 +55,7 @@ RSpec.describe Multidb::Balancer do
         end
 
         it 'sets fallback to true' do
-          expect(subject.fallback).to eq(true)
+          expect(subject.fallback).to be(true)
         end
       end
     end
@@ -78,7 +78,7 @@ RSpec.describe Multidb::Balancer do
       end
 
       it 'sets fallback to true' do
-        expect(subject.fallback).to eq(true)
+        expect(subject.fallback).to be(true)
       end
     end
 

--- a/spec/lib/multidb/candidate_spec.rb
+++ b/spec/lib/multidb/candidate_spec.rb
@@ -17,16 +17,6 @@ RSpec.describe Multidb::Candidate do
         handler = subject.instance_variable_get(:@connection_handler)
         expect(handler).to an_instance_of(ActiveRecord::ConnectionAdapters::ConnectionHandler)
       end
-
-      it 'merges the name: primary into the hash', rails: '< 6.1' do
-        handler = instance_double('ActiveRecord::ConnectionAdapters::ConnectionHandler')
-        allow(ActiveRecord::ConnectionAdapters::ConnectionHandler).to receive(:new).and_return(handler)
-        allow(handler).to receive(:establish_connection)
-
-        subject
-
-        expect(handler).to have_received(:establish_connection).with(hash_including(name: 'primary'))
-      end
     end
 
     context 'when target is a connection handler' do

--- a/spec/lib/multidb/log_subscriber_extension_spec.rb
+++ b/spec/lib/multidb/log_subscriber_extension_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Multidb::LogSubscriberExtension do
       end
 
       it 'does not change the payload' do
-        expect { subject }.not_to change { event.payload }
+        expect { subject }.not_to(change { event.payload })
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@ require 'fileutils'
 $LOAD_PATH.unshift(File.expand_path('lib', __dir__))
 require 'multidb'
 
-Dir[File.join(__dir__, 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[File.join(__dir__, 'support', '**', '*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
   config.disable_monkey_patching!
@@ -39,7 +39,7 @@ RSpec.configure do |config|
   end
 
   config.before do
-    ActiveRecord::Base.clear_all_connections!
+    ActiveRecord::Base.connection_handler.clear_all_connections!
     Multidb.reset!
   end
 


### PR DESCRIPTION
- Add support for activerecord 7.2 and 8.0
- Add Ruby 3.1-3.4 and activerrecord 7.2 and 8.0 to test matrix

Breaking: Drop Support for old unsupported versions

- Drop support for Ruby < 3.0
- Drop support for activerecord < 7.1