### PR TITLE
Add support for Rails 8.1

### DIFF
--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -25,13 +25,18 @@ jobs:
         - '7.1'
         - '7.2'
         - '8.0'
+        - '8.1'
         exclude:
         - ruby: '3.0'
           activerecord: '7.2'
         - ruby: '3.0'
           activerecord: '8.0'
+        - ruby: '3.0'
+          activerecord: '8.1'
         - ruby: '3.1'
           activerecord: '8.0'
+        - ruby: '3.1'
+          activerecord: '8.1'
     env:
       BUNDLE_GEMFILE: "${{ github.workspace }}/gemfiles/activerecord-${{ matrix.activerecord }}.gemfile"
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
+## [0.8.2]
+### Changed
+- add support for Rails 8.1
+
 ## [0.8.1]
 ### Changes
 - Updated Log subscriber mixin to utilize Rails 7.1's contract for "color"

--- a/ar-multidb.gemspec
+++ b/ar-multidb.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 3.0.0'
 
-  s.add_runtime_dependency 'activerecord', '>= 7.1', '< 8.1'
-  s.add_runtime_dependency 'activesupport', '>= 7.1', '< 8.1'
+  s.add_runtime_dependency 'activerecord', '>= 7.1', '< 8.2'
+  s.add_runtime_dependency 'activesupport', '>= 7.1', '< 8.2'
 
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3.8'

--- a/gemfiles/activerecord-8.1.gemfile
+++ b/gemfiles/activerecord-8.1.gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'activerecord', '~> 8.1.0'
+
+gemspec path: '..'

--- a/lib/multidb/version.rb
+++ b/lib/multidb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Multidb
-  VERSION = '0.8.1'
+  VERSION = '0.8.2'
 end


### PR DESCRIPTION
Add support for `activerecord` and `activesupport` 8.1

- Bump version constraint from `< 8.1` to `< 8.2` in gemspec
- Add `gemfiles/activerecord-8.1.gemfile`
- Add Rails 8.1 to CI test matrix (Ruby 3.2+ only, as required by Rails 8.1)
- Bump version to 0.8.2